### PR TITLE
fix: bump simple-slack-api to 1.4

### DIFF
--- a/frontends/slack/build.gradle
+++ b/frontends/slack/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        version_slackapi = 'd3fe7de811'
+        version_slackapi = '1.4.0'
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/frontends/slack/src/main/kotlin/com/gatehill/corebot/frontend/slack/chat/SlackSessionServiceImpl.kt
+++ b/frontends/slack/src/main/kotlin/com/gatehill/corebot/frontend/slack/chat/SlackSessionServiceImpl.kt
@@ -72,9 +72,9 @@ open class SlackSessionServiceImpl @Inject constructor(configService: ConfigServ
     private fun sendMessage(channel: SlackChannel, triggerMessageTimestamp: String,
                             triggerMessageThreadTimestamp: String?, message: String) {
 
-        val messageBuilder = SlackPreparedMessage.Builder().apply {
-            withMessage(message)
-            withUnfurl(true)
+        val messageBuilder = SlackPreparedMessage.builder().apply {
+            message(message)
+            unfurl(true)
 
             // the 'replyInThread' setting implies 'allowThreadedTriggers'
             if (ChatSettings.threads.replyInThread || ChatSettings.threads.allowThreadedTriggers) {
@@ -86,7 +86,7 @@ open class SlackSessionServiceImpl @Inject constructor(configService: ConfigServ
                     triggerMessageTimestamp
                 }
 
-                withThreadTimestamp(timestamp)
+                threadTimestamp(timestamp)
             }
         }
 


### PR DESCRIPTION
This includes a replacement for the deprecated RTM API call.

Fixes #63 